### PR TITLE
Add footnote for Payment Rails => Trolley rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Payment Rails JAVA SDK
+# Payment Rails[^1] JAVA SDK
 
 A native JAVA SDK for the Payment Rails API
+
+[^1]: [Payment Rails is now Trolley](https://www.trolley.com/payment-rails-is-now-trolley-series-a), we'll be updating our SDKs to support the new domain during the first half of 2022.
 
 ## Installation
 


### PR DESCRIPTION
The plan is to update SKDs to support the new domain during the first half of 2022 (also noted in the README).