### PR TITLE
fix: Switch HttpClient to use System properties

### DIFF
--- a/src/main/java/com/trolley/trolley/Client.java
+++ b/src/main/java/com/trolley/trolley/Client.java
@@ -130,7 +130,7 @@ public class Client
     public String patch(final String endPoint, final String body) throws Exception {
         String StringResponse = "";
         try {
-            final HttpClient httpclient = (HttpClient)HttpClients.createDefault();
+            final HttpClient httpclient = (HttpClient)HttpClients.createSystem();
             final HttpPatch httpPatch = new HttpPatch(this.config.getApiBase() + endPoint);
             final StringEntity params = new StringEntity(body);
             final int timeStamp = (int)(System.currentTimeMillis() / 1000L);


### PR DESCRIPTION
# Fixes #

Currently the SDK only respects system configuration of HTTP proxies for HTTP methods GET, POST, DELETE but not PATCH.

This is due to the non PATCH methods using the Java HTTP library which respects system properties by default, whereas the PATCH implementation uses Apache HTTP client which needs to be explicitly configured to do so. 

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
