### PR TITLE
fix: Update searchInvoices to use array for external ids + use lower camel case for search param

### DIFF
--- a/src/main/java/com/trolley/trolley/InvoiceGateway.java
+++ b/src/main/java/com/trolley/trolley/InvoiceGateway.java
@@ -141,11 +141,12 @@ public class InvoiceGateway
             case INVOICE_ID:
             case RECIPIENT_ID:
             case INVOICE_NUMBER:
+            case EXTERNAL_ID:
             case TAGS:
                 if(null == paramsList){
                     throw new InvalidFieldException("variable paramsList can not be null for the provided searchBy parameter. Refer to method's Javadoc for more details.");
                 }
-                body = "{\""+searchBy.name()+"\":"
+                body = "{\""+searchBy.getKey()+"\":"
                     +new ObjectMapper()
                         .setSerializationInclusion(Include.NON_EMPTY)
                         .writeValueAsString(paramsList)
@@ -153,11 +154,10 @@ public class InvoiceGateway
                 break;
 
             case INVOICE_DATE:
-            case EXTERNAL_ID:
                 if(null == param){
                     throw new InvalidFieldException("variable param can not be null for the provided searchBy parameter. Refer to method's Javadoc for more details.");
                 }
-                body = "{\""+searchBy.name()+"\":\""+param+"\"}";
+                body = "{\""+searchBy.getKey()+"\":\""+param+"\"}";
                 break;
         }
         final String endPoint = "/v1/invoices/search/";


### PR DESCRIPTION
# Fixes #

I noticed that the searchInvoices API actually expects the search parameter (e.g. `externalId`) in lowerCamelCase.
However the SDK currently sends it in UPPER_SNAKE_CASE.

Additionally, if using `externalId` filtering, it should be an array of values, rather than a single value ([according to the API](https://docs.trolley.com/api/#search-invoices) + from my testing)

<img width="729" alt="Screenshot 2023-08-18 at 1 51 35 pm" src="https://github.com/trolley/java-sdk/assets/1754944/d28789c0-9868-4e56-82c0-56954162f2cb">

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
