### PR TITLE
fix: Allow coverFees to be null (optional) on InvoicePaymentRequest

### DIFF
--- a/src/main/java/com/trolley/types/supporting/InvoicePaymentRequest.java
+++ b/src/main/java/com/trolley/types/supporting/InvoicePaymentRequest.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
  */
 public class InvoicePaymentRequest{
     private String batchId;
-    private boolean coverFees;
+    private Boolean coverFees;
     private String memo;
     private String externalId;
     private String[] tags;
@@ -25,7 +25,7 @@ public class InvoicePaymentRequest{
      * @param tags A {@code String[]} array where each element is a merchant-viewable tag that you want to assign to the created payment.
      * @param ids An {@code InvoicePaymentPart[]} array representing InvoicePaymentPart objects containing IDs and Amounts of Invoices and InvoiceLines you want to create payments for.
      */
-    public InvoicePaymentRequest(String batchId, boolean coverFees, String memo, String externalId,
+    public InvoicePaymentRequest(String batchId, Boolean coverFees, String memo, String externalId,
             String[] tags, InvoicePaymentPart[] ids) {
         this.batchId = batchId;
         this.coverFees = coverFees;
@@ -44,7 +44,7 @@ public class InvoicePaymentRequest{
      * @param tags A {@code String[]} array where each element is a merchant-viewable tag that you want to assign to the created payment.
      * @param ids An {@code InvoicePaymentPart[]} array representing InvoicePaymentPart objects containing IDs and Amounts of Invoices and InvoiceLines you want to create payments for.
      */
-    public InvoicePaymentRequest(String batchId, boolean coverFees, String memo, String externalId,
+    public InvoicePaymentRequest(String batchId, Boolean coverFees, String memo, String externalId,
             String[] tags, InvoicePaymentPart paymentPart) {
         this.batchId = batchId;
         this.coverFees = coverFees;
@@ -62,11 +62,11 @@ public class InvoicePaymentRequest{
         this.batchId = batchId;
     }
 
-    public boolean shouldCoverFees() {
+    public Boolean shouldCoverFees() {
         return coverFees;
     }
 
-    public void setCoverFees(boolean coverFees) {
+    public void setCoverFees(Boolean coverFees) {
         this.coverFees = coverFees;
     }
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

The create invoice payment API specifies that coverFees is optional, however, the field is a `boolean` (primitive) in `InvoicePaymentRequest`, which means it must be provided.

This PR updates it to `Boolean` which will allow nulls, and therefore won't send any value for this when it's serialized as JSON.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
