### PR TITLE
chore: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+## Cursor Cloud specific instructions
+
+This is the **Trolley Java SDK** — a pure Java HTTP client library for the Trolley payments API. There are no local services, databases, or containers to run.
+
+### Build & test commands
+
+- **Compile:** `mvn compile -B`
+- **Package (skip tests + GPG):** `mvn package -DskipTests -Dgpg.skip=true -B`
+- **Run tests:** `mvn test -B` (requires valid API credentials; see below)
+
+Set `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64` before running Maven commands — the javadoc plugin requires it.
+
+### Integration tests & credentials
+
+All tests under `src/test/java/com/trolley/integration/` are **live integration tests** that call the Trolley API at `api.trolley.com`. They require a `.env` file in the repo root with:
+
+```
+ACCESS_KEY=<your-trolley-access-key>
+SECRET_KEY=<your-trolley-secret-key>
+```
+
+Without valid credentials, all 18 tests will fail with `AuthenticationException`. This is expected behavior — there are no unit tests or mocked tests in this repository.
+
+### JVM config
+
+The `.mvn/jvm.config` file contains `--add-opens` flags required for PowerMock compatibility with modern JDKs. These are picked up automatically by Maven.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Fixes #

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the Trolley Java SDK.

### What this PR does

Adds an `AGENTS.md` file documenting:
- Build and test commands (`mvn compile`, `mvn test`, `mvn package`)
- `JAVA_HOME` requirement for the javadoc plugin
- Integration test credential requirements (`.env` with `ACCESS_KEY` / `SECRET_KEY`)
- JVM config notes for PowerMock compatibility

### Evidence of working environment

[build_and_hello_world.log](https://cursor.com/agents/bc-33f98ad0-6363-416f-85b0-d5c95a1f3b16/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_hello_world.log)

**Build verification:**
- `mvn compile` — 60 source files compiled successfully
- `mvn test-compile` — test sources compiled successfully
- `mvn package -DskipTests -Dgpg.skip=true` — JAR, sources JAR, and javadoc JAR built
- `mvn test` — all 18 integration tests ran (fail with `AuthenticationException` without API credentials — expected)
- Hello world program exercising the SDK's Configuration, Gateway, and HTTP layer — all working

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f98ad0-6363-416f-85b0-d5c95a1f3b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f98ad0-6363-416f-85b0-d5c95a1f3b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

