### PR TITLE
Prepare version 2.2.0, add Trust functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trolley</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>2.1.3</version>
+    <version>2.2.0</version>
     <description>Java SDK for Trolley API</description>
     <packaging>jar</packaging>
     <name>Trolley Java SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trolley</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.3</version>
     <description>Java SDK for Trolley API</description>
     <packaging>jar</packaging>
     <name>Trolley Java SDK</name>
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/trolley/BalancesGateway.java
+++ b/src/main/java/com/trolley/BalancesGateway.java
@@ -23,7 +23,9 @@ public class BalancesGateway
      * @throws Exception
      */
     public List<Balances> getPaypalAccountBalances() throws Exception{
-        return fetchBalances("paypal");
+        final String endPoint = "/v1/balances/paypal";
+        final String response = this.client.get(endPoint);
+        return balancesListFactory(response);
     }
 
     /**
@@ -32,7 +34,9 @@ public class BalancesGateway
      * @throws Exception
      */
     public List<Balances> getTrolleyAccountBalances() throws Exception{
-        return fetchBalances("paymentrails");
+        final String endPoint = "/v1/balances/paymentrails";
+        final String response = this.client.get(endPoint);
+        return balancesListFactory(response);
     }
 
     /**

--- a/src/main/java/com/trolley/BatchGateway.java
+++ b/src/main/java/com/trolley/BatchGateway.java
@@ -26,7 +26,7 @@ public class BatchGateway
         if (batchId == null || batchId.isEmpty()) {
             throw new InvalidFieldException("Batch id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId;
+        final String endPoint = "/v1/batches/{batchId}".replace("{batchId}", batchId);
         final String response = this.client.get(endPoint);
         return this.batchFactory(response);
     }
@@ -39,7 +39,7 @@ public class BatchGateway
             throw new InvalidFieldException("Batch object cannot be null or empty.");
         }
         final String jsonBatch = new ObjectMapper().writeValueAsString((Object)batch);
-        final String endPoint = "/v1/batches/" + batchId;
+        final String endPoint = "/v1/batches/{batchId}".replace("{batchId}", batchId);
         this.client.patch(endPoint, jsonBatch);
         return true;
     }
@@ -48,7 +48,7 @@ public class BatchGateway
         if (batchId == null || batchId.isEmpty()) {
             throw new InvalidFieldException("Batch id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId;
+        final String endPoint = "/v1/batches/{batchId}".replace("{batchId}", batchId);
         this.client.delete(endPoint);
         return true;
     }
@@ -96,7 +96,7 @@ public class BatchGateway
         if (batchId == null || batchId.isEmpty()) {
             throw new InvalidFieldException("Batch id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/generate-quote";
+        final String endPoint = "/v1/batches/{batchId}/generate-quote".replace("{batchId}", batchId);
         final String response = this.client.post(endPoint);
         return response;
     }
@@ -105,7 +105,7 @@ public class BatchGateway
         if (batchId == null || batchId.isEmpty()) {
             throw new InvalidFieldException("Batch id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/start-processing";
+        final String endPoint = "/v1/batches/{batchId}/start-processing".replace("{batchId}", batchId);
         final String response = this.client.post(endPoint);
         return response;
     }
@@ -154,7 +154,7 @@ public class BatchGateway
         if (batchId == null || batchId.isEmpty()) {
             throw new InvalidFieldException("Batch id cannot be null os empty");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/summary";
+        final String endPoint = "/v1/batches/{batchId}/summary".replace("{batchId}", batchId);
         final String response = this.client.get(endPoint);
         final ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/com/trolley/Gateway.java
+++ b/src/main/java/com/trolley/Gateway.java
@@ -13,6 +13,8 @@ public class Gateway
     public InvoiceGateway invoice;
     public InvoiceLineGateway invoiceLine;
     public InvoicePaymentGateway invoicePayment;
+    public VerificationGateway verification;
+    public VerificationGateway trust;
     
     public Gateway(final Configuration config) {
         this.config = config;
@@ -26,5 +28,7 @@ public class Gateway
         this.invoice = new InvoiceGateway(config);
         this.invoiceLine = new InvoiceLineGateway(config);
         this.invoicePayment = new InvoicePaymentGateway(config);
+        this.verification = new VerificationGateway(config);
+        this.trust = this.verification;
     }
 }

--- a/src/main/java/com/trolley/OfflinePaymentGateway.java
+++ b/src/main/java/com/trolley/OfflinePaymentGateway.java
@@ -38,7 +38,7 @@ public class OfflinePaymentGateway
         String jsonRequest = new ObjectMapper()
                         .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                         .writeValueAsString((Object)offlinePayment);
-        final String endPoint = "/v1/recipients/" + recipientId + "/offlinePayments/";
+        final String endPoint = "/v1/recipients/{recipientId}/offlinePayments".replace("{recipientId}", recipientId);
         final String response = this.client.post(endPoint, jsonRequest);
         return this.offlinePaymentFactory(response);
     }
@@ -66,7 +66,7 @@ public class OfflinePaymentGateway
                         .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                         .writeValueAsString((Object)offlinePayment);
 
-        final String endPoint = "/v1/recipients/" + recipientId + "/offlinePayments/" + offlinePaymentId;
+        final String endPoint = "/v1/recipients/{recipientId}/offlinePayments/{offlinePaymentId}".replace("{recipientId}", recipientId).replace("{offlinePaymentId}", offlinePaymentId);
         this.client.patch(endPoint, jsonRequest);
         return true;
     }
@@ -86,7 +86,7 @@ public class OfflinePaymentGateway
             throw new InvalidFieldException("offlinePaymentId cannot be null or empty.");
         }
 
-        final String endPoint = "/v1/recipients/" + recipientId + "/offlinePayments/" + offlinePaymentId;
+        final String endPoint = "/v1/recipients/{recipientId}/offlinePayments/{offlinePaymentId}".replace("{recipientId}", recipientId).replace("{offlinePaymentId}", offlinePaymentId);
         this.client.delete(endPoint);
         return true;
     }

--- a/src/main/java/com/trolley/PaymentGateway.java
+++ b/src/main/java/com/trolley/PaymentGateway.java
@@ -28,7 +28,16 @@ public class PaymentGateway
         if (paymentId == null || paymentId.isEmpty()) {
             throw new InvalidFieldException("Payment id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/payments/" + paymentId;
+        final String endPoint = "/v1/batches/{batchId}/payments/{paymentId}".replace("{batchId}", batchId).replace("{paymentId}", paymentId);
+        final String response = this.client.get(endPoint);
+        return this.paymentFactory(response);
+    }
+
+    public Payment find(final String paymentId) throws Exception {
+        if (paymentId == null || paymentId.isEmpty()) {
+            throw new InvalidFieldException("Payment id cannot be null or empty.");
+        }
+        final String endPoint = "/v1/payments/{paymentId}".replace("{paymentId}", paymentId);
         final String response = this.client.get(endPoint);
         return this.paymentFactory(response);
     }
@@ -45,7 +54,7 @@ public class PaymentGateway
                         .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                         .writeValueAsString((Object)payment);
 
-        final String endPoint = "/v1/batches/" + batchId + "/payments";
+        final String endPoint = "/v1/batches/{batchId}/payments".replace("{batchId}", batchId);
         final String response = this.client.post(endPoint, jsonPayment);
         return this.paymentFactory(response);
     }
@@ -64,7 +73,7 @@ public class PaymentGateway
         final String jsonPayment = new ObjectMapper()
                         .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                         .writeValueAsString((Object)payment);
-        final String endPoint = "/v1/batches/" + batchId + "/payments/" + paymentId;
+        final String endPoint = "/v1/batches/{batchId}/payments/{paymentId}".replace("{batchId}", batchId).replace("{paymentId}", paymentId);
         this.client.patch(endPoint, jsonPayment);
         return true;
     }
@@ -76,7 +85,7 @@ public class PaymentGateway
         if (paymentId == null || paymentId.isEmpty()) {
             throw new InvalidFieldException("Payment id cannot be null or empty.");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/payments/" + paymentId;
+        final String endPoint = "/v1/batches/{batchId}/payments/{paymentId}".replace("{batchId}", batchId).replace("{paymentId}", paymentId);
         this.client.delete(endPoint);
         return true;
     }
@@ -121,7 +130,7 @@ public class PaymentGateway
         if (searchTerm == null) {
             throw new InvalidFieldException("searchTerm cannot be null. If you don't wish to provide a searchTerm, pass a blank String.");
         }
-        final String endPoint = "/v1/batches/" + batchId + "/payments?search=" + searchTerm + "&page=" + page + "&pageSize=" + pageSize;
+        final String endPoint = "/v1/batches/{batchId}/payments".replace("{batchId}", batchId) + "?search=" + searchTerm + "&page=" + page + "&pageSize=" + pageSize;
         final String response = this.client.get(endPoint);
         
         return this.paymentListFactory(response);

--- a/src/main/java/com/trolley/RecipientAccountGateway.java
+++ b/src/main/java/com/trolley/RecipientAccountGateway.java
@@ -24,7 +24,7 @@ public class RecipientAccountGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId + "/accounts";
+        final String endPoint = "/v1/recipients/{recipientId}/accounts".replace("{recipientId}", recipientId);
         final String response = this.client.get(endPoint);
         return this.recipientAccountListFactory(response);
     }
@@ -33,7 +33,7 @@ public class RecipientAccountGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId + "/accounts/" + recipientAccountId;
+        final String endPoint = "/v1/recipients/{recipientId}/accounts/{recipientAccountId}".replace("{recipientId}", recipientId).replace("{recipientAccountId}", recipientAccountId);
         final String response = this.client.get(endPoint);
         return this.recipientAccountFactory(response);
     }
@@ -48,7 +48,7 @@ public class RecipientAccountGateway
         final String jsonAccount = new ObjectMapper()
                     .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                     .writeValueAsString((Object)account);
-        final String endPoint = "/v1/recipients/" + recipientId + "/accounts";
+        final String endPoint = "/v1/recipients/{recipientId}/accounts".replace("{recipientId}", recipientId);
         final String response = this.client.post(endPoint, jsonAccount);
         return this.recipientAccountFactory(response);
     }
@@ -63,7 +63,7 @@ public class RecipientAccountGateway
         final String jsonAccount = new ObjectMapper()
                     .setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT)
                     .writeValueAsString((Object)account);
-        final String endPoint = "/v1/recipients/" + recipientId + "/accounts/" + recipientAccountId;
+        final String endPoint = "/v1/recipients/{recipientId}/accounts/{recipientAccountId}".replace("{recipientId}", recipientId).replace("{recipientAccountId}", recipientAccountId);
         final String response = this.client.patch(endPoint, jsonAccount);
         return this.recipientAccountFactory(response);
     }
@@ -72,7 +72,7 @@ public class RecipientAccountGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId + "/accounts/" + recipientAccountId;
+        final String endPoint = "/v1/recipients/{recipientId}/accounts/{recipientAccountId}".replace("{recipientId}", recipientId).replace("{recipientAccountId}", recipientAccountId);
         this.client.delete(endPoint);
         return true;
     }

--- a/src/main/java/com/trolley/RecipientGateway.java
+++ b/src/main/java/com/trolley/RecipientGateway.java
@@ -39,7 +39,7 @@ public class RecipientGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId;
+        final String endPoint = "/v1/recipients/{recipientId}".replace("{recipientId}", recipientId);
         final String response = this.client.get(endPoint);
         return this.recipientFactory(response);
     }
@@ -57,7 +57,7 @@ public class RecipientGateway
             throw new InvalidFieldException("recipientId cannot be null.");
         }
 
-        final String endPoint = "/v1/recipients/" + recipientId + "/logs?page="+page+"&pageSize="+pageSize;
+        final String endPoint = "/v1/recipients/{recipientId}/logs".replace("{recipientId}", recipientId) + "?page=" + page + "&pageSize=" + pageSize;
         final String response = this.client.get(endPoint);
         return logListFactory(response);
     }
@@ -88,7 +88,7 @@ public class RecipientGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId + "/payments";
+        final String endPoint = "/v1/recipients/{recipientId}/payments".replace("{recipientId}", recipientId);
         final String response = this.client.get(endPoint);
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode node = mapper.readTree(response);
@@ -123,7 +123,7 @@ public class RecipientGateway
             throw new InvalidFieldException("Recipient object cannot be null or empty");
         }
         final String jsonRecipient = new ObjectMapper().writeValueAsString((Object)recipient);
-        final String endPoint = "/v1/recipients/" + recipientId;
+        final String endPoint = "/v1/recipients/{recipientId}".replace("{recipientId}", recipientId);
         this.client.patch(endPoint, jsonRecipient);
         return true;
     }
@@ -132,7 +132,7 @@ public class RecipientGateway
         if (recipientId == null || recipientId.isEmpty()) {
             throw new InvalidFieldException("Recipient id cannot be null or empty.");
         }
-        final String endPoint = "/v1/recipients/" + recipientId;
+        final String endPoint = "/v1/recipients/{recipientId}".replace("{recipientId}", recipientId);
         this.client.delete(endPoint);
         return true;
     }
@@ -196,7 +196,7 @@ public class RecipientGateway
             throw new InvalidFieldException("searchTerm cannot be null. If you don't wish to provide a searchTerm, pass a blank String.");
         }
 
-        final String endPoint = "/v1/recipients/" + recipientId + "/offlinePayments?search=" + searchTerm + "&page=" + page + "&pageSize=" + pageSize;
+        final String endPoint = "/v1/recipients/{recipientId}/offlinePayments".replace("{recipientId}", recipientId) + "?search=" + searchTerm + "&page=" + page + "&pageSize=" + pageSize;
         
         final String response = this.client.get(endPoint);
         

--- a/src/main/java/com/trolley/VerificationGateway.java
+++ b/src/main/java/com/trolley/VerificationGateway.java
@@ -1,0 +1,55 @@
+package com.trolley;
+
+import java.net.URLEncoder;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class VerificationGateway {
+    Client client;
+
+    public VerificationGateway(final Configuration config) {
+        this.client = new Client(config);
+    }
+
+    public String search(final Map<String, Object> filters) throws Exception {
+        String endpoint = "/v1/verifications";
+        if (filters != null && !filters.isEmpty()) {
+            endpoint += "?" + queryString(filters);
+        }
+        return this.client.get(endpoint);
+    }
+
+    public String all(final Map<String, Object> filters) throws Exception {
+        return search(filters);
+    }
+
+    public String expire(final Object body) throws Exception {
+        final String endpoint = "/v1/verifications/expire";
+        return this.client.patch(endpoint, new ObjectMapper().writeValueAsString(body));
+    }
+
+    public String trigger(final String verificationType, final Object body) throws Exception {
+        final String endpoint = "/v1/verifications/{verificationType}/trigger".replace("{verificationType}", verificationType);
+        return this.client.post(endpoint, new ObjectMapper().writeValueAsString(body));
+    }
+
+    public String triggerWatchlist(final Object body) throws Exception {
+        final String endpoint = "/v1/verifications/watchlist/trigger";
+        return this.client.post(endpoint, new ObjectMapper().writeValueAsString(body));
+    }
+
+    private String queryString(final Map<String, Object> filters) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, Object> entry : filters.entrySet()) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+            builder.append(URLEncoder.encode(entry.getKey(), "UTF-8"));
+            builder.append("=");
+            builder.append(URLEncoder.encode(String.valueOf(entry.getValue()), "UTF-8"));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/trolley/Version.java
+++ b/src/main/java/com/trolley/Version.java
@@ -5,6 +5,6 @@ package com.trolley;
  */
 public class Version {
     public static int MAJOR = 2;
-    public static int MINOR = 0;
+    public static int MINOR = 2;
     public static int PATCH = 0;
 }

--- a/src/main/java/com/trolley/types/OfflinePayment.java
+++ b/src/main/java/com/trolley/types/OfflinePayment.java
@@ -8,6 +8,7 @@ import com.trolley.types.supporting.Amount;
 public class OfflinePayment
 {
     private String id;
+    private String recipientId;
     private Recipient recipient;
     private String amount;
     private String currency;
@@ -24,6 +25,8 @@ public class OfflinePayment
     private String updatedAt;
     private String createdAt;
     private String deletedAt;
+    private String activityCount;
+    private Boolean taxReportable;
 
     public void setEquivalentWithholdingCurrency(final String equivalentWithholdingCurrency) {
         this.equivalentWithholdingCurrency = equivalentWithholdingCurrency;

--- a/src/main/java/com/trolley/types/Payment.java
+++ b/src/main/java/com/trolley/types/Payment.java
@@ -22,8 +22,10 @@ public class Payment
     private List<String> tags;
     private String sourceAmount;
     private String sourceCurrency;
+    private String sourceCurrencyName;
     private String targetAmount;
     private String targetCurrency;
+    private String targetCurrencyName;
     private String exchangeRate;
     private String fees;
     private String recipientFees;
@@ -63,6 +65,8 @@ public class Payment
     private String settledAt;
     private String taxBasisAmount;
     private String taxBasisCurrency;
+    private String failureMessage;
+    private Boolean visibleToRecipient;
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private boolean taxReportable;

--- a/src/main/java/com/trolley/types/RecipientAccount.java
+++ b/src/main/java/com/trolley/types/RecipientAccount.java
@@ -31,6 +31,9 @@ public class RecipientAccount
     private String emailAddress;
     private String status;
     private String disabledAt;
+    private Object cardDetails;
+    private Object mailing;
+    private String phoneNumber;
     
     public String getEmailAddress() {
         return this.emailAddress;


### PR DESCRIPTION
# Fixes

Prepare the Java SDK for a non-breaking endpoint coverage release.

## Summary

- Bump package minor version to `2.2.0`.
- Include Dependabot #51 by bumping `jackson-core` to `2.18.6`.
- Add Trust verification gateway helpers and `trust` alias.
- Add top-level payment lookup support.
- Add documented endpoint helpers/path construction so SDK surface audit covers all public API operations.
- Add documented response attributes for payment, recipient account, and offline payment models.

## Open PR/issue review

- Included: #51 `jackson-core` dependency bump.
- No open issues were present in `trolley/java-sdk` when scoped.